### PR TITLE
"named data volumes" instead of "data container" with "data volumes"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,12 @@
 version: '2'
 
-services:
-  pmm-data:
-    build: .
-    image: percona/pmm-server
-    container_name: pmm-data
-    volumes:
-      - /opt/prometheus/data
-      - /opt/consul-data
-      - /var/lib/mysql
-      - /var/lib/grafana
-    entrypoint: /bin/true
+volumes:
+  pmm-data-prometheus:
+  pmm-data-consul:
+  pmm-data-mysql:
+  pmm-data-grafana:
 
+services:
   pmm-server:
     build: .
     container_name: pmm-server
@@ -20,9 +15,11 @@ services:
     ports:
       - "80:80"
 #      - "443:443"
-    volumes_from:
-      - pmm-data
-#    volumes:
+    volumes:
+      - pmm-data-prometheus:/opt/prometheus/data
+      - pmm-data-consul:/opt/consul-data
+      - pmm-data-mysql:/var/lib/mysql
+      - pmm-data-grafana:/var/lib/grafana
 #      - /root/docker_shared_volumes/ssl:/etc/nginx/ssl
     environment:
       - METRICS_RETENTION=720h


### PR DESCRIPTION
Since version 1.9 docker allows using named data volumes, which basically make data containers obsolete. Instead of creating data container, we can now create just the volumes.

```
version: '2'

volumes:
  pmm-data-prometheus:
  pmm-data-consul:
  pmm-data-mysql:
  pmm-data-grafana:

services:
  pmm-server:
    build: .
    container_name: pmm-server
    image: percona/pmm-server
    restart: always
    ports:
      - "80:80"
#      - "443:443"
    volumes:
      - pmm-data-prometheus:/opt/prometheus/data
      - pmm-data-consul:/opt/consul-data
      - pmm-data-mysql:/var/lib/mysql
      - pmm-data-grafana:/var/lib/grafana
#      - /root/docker_shared_volumes/ssl:/etc/nginx/ssl
    environment:
      - METRICS_RETENTION=720h
      - METRICS_MEMORY=262144
      - METRICS_RESOLUTION=1s
      - QUERIES_RETENTION=8
      - ORCHESTRATOR_USER=orc_client_user
      - ORCHESTRATOR_PASSWORD=orc_client_password
      - SERVER_USER=pmm
      - SERVER_PASSWORD=
```

This has several benefits e.g.:
* old "volumes_from" is not supported in `docker-compose` version "3" (https://docs.docker.com/compose/compose-file/#version-3)
* there is no "fake" container to store the data, so there is only one container for application instead of two. It's also more logical as "containers" are separated from "volumes".
* `docker volume ls` lists volumes with names, so you can easily identify the volume instead of hash uuids
  old: 
  ```
  $ docker volume ls
  DRIVER              VOLUME NAME
  local               3fe341b77363c656c8ae7f66b8926d5bac1f3e9425666a1dd3c18fd374e57650
  local               729d0d1b1803f02534f214129d815935a5fa56c651f1283a73606a21a8fcc607
  local               a47217b03a47ef01b42156e4762cd608448759cf51191f31d5246c455c01cb3a
  local               d5163bf53654f0393a076150dc0b9e2ea83df1abe6be6815afff993a22f7e67f
  ```
  new:
  ```
  $ docker volume ls
  DRIVER              VOLUME NAME
  local               pmmserver_pmm-data-consul
  local               pmmserver_pmm-data-grafana
  local               pmmserver_pmm-data-mysql
  local               pmmserver_pmm-data-prometheus
  ```
* for running manually only one command is necessary `docker run`, as volumes will be created automatically if they don't exist
  ```
  docker run -d -p 80:80 \
  -v pmm-data-prometheus:/opt/prometheus/data \
  -v pmm-data-consul:/opt/consul-data \
  -v pmm-data-mysql:/var/lib/mysql \
  -v pmm-data-grafana:/var/lib/grafana \
  --name pmm-server --restart always percona/pmm-server:latest
  ```
* in theory might be easier to deploy pmm-server to ECS, since there is no need for one container to depend on another - however I didn't test yet pmm-server on ECS

This doesn't bring significant improvement so please treat this just as proposal or for future reference if there will be need to use this method - just wanted to share there is a different method, maybe simpler.