### PR TITLE
Change the entrypoint so that supervisor is PID 1 inside the container.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,4 +39,4 @@ fi
 sed -i "s/ENV_AUTH_BASIC/${ENV_AUTH_BASIC}/" /etc/supervisor/supervisord.conf
 
 # Start supervisor in foreground
-supervisord -c /etc/supervisor/supervisord.conf
+exec supervisord -c /etc/supervisor/supervisord.conf


### PR DESCRIPTION
Supervisor provides an awesome way to send signals to all running processes but in order to do capture signals from the docker daemon it has to be PID 1.
Here's a simple post on why this is important:
https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/

At the moment a pstree inside your container looks like this:
entrypoint.sh---supervisord-+-bash---bash---percona-qan-api-+-perl
                            |                               `-6*[{percona-qan-api}]
                            |-bash---orchestrator---7*[{orchestrator}]
                            |-consul---9*[{consul}]
                            |-cron
                            |-grafana-server---8*[{grafana-server}]
                            |-mysqld_safe---mysqld---18*[{mysqld}]
                            |-nginx---4*[nginx]
                            |-node_exporter---6*[{node_exporter}]
                            `-prometheus---8*[{prometheus}]

Great work with PMM!
Thanks!