### PR TITLE
PMM-1519 add prometheus stop timeout

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -103,6 +103,7 @@ command =
 stdout_logfile = /var/log/prometheus.log
 stderr_logfile = /var/log/prometheus.log
 autorestart = true
+stopwaitsecs = 300
 
 # This is here to support data containers of v1.0.4.
 [program:createdb]


### PR DESCRIPTION
issue: large installations cannot be stopped successfully without long crash recovery on start.