### PR TITLE
Set Grafana's Working Directory

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -45,6 +45,7 @@ autorestart = true
 [program:grafana]
 priority = 3
 user = grafana
+directory = /usr/share/grafana
 environment = HOME=/usr/share/grafana
 command =
     /usr/sbin/grafana-server


### PR DESCRIPTION
Some Grafana functionality uses relative path to cwd

For example, the Slack implementation uses it until the 4.7 release.
https://github.com/grafana/grafana/issues/10012