### PR TITLE
PMM-1987 modification to allow the use of an index on sec in order to fix a very bad query

### DIFF
--- a/purge-qan-data
+++ b/purge-qan-data
@@ -38,7 +38,7 @@ do_table() {
 
 ts "Starting to purge $DB data older than $INTERVAL days."
 
-do_table "agent_log" "FROM_UNIXTIME(sec) < NOW() - INTERVAL $INTERVAL DAY"
+do_table "agent_log" "sec < UNIX_TIMESTAMP(NOW() - INTERVAL $INTERVAL DAY)"
 do_table "query_examples" "period < NOW() - INTERVAL $INTERVAL DAY"
 do_table "query_global_metrics" "start_ts < NOW() - INTERVAL $INTERVAL DAY"
 do_table "query_class_metrics" "start_ts < NOW() - INTERVAL $INTERVAL DAY"


### PR DESCRIPTION
The pt-archiver rule for agent_log is not correct.  NEVER put a function on a column in the where clause.   My home setup ended up will millions of rows in agent_log and a constant load.