### PR TITLE
PMM-1986: Signing out with HTTP auth enabled leaves the browser "signed in"

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -37,6 +37,16 @@
 			proxy_read_timeout	600;
 		}
 
+                location = /graph/logout {
+                    if ($realm = "on") {
+                        # Force browser to reauthenticate
+                        return 307 $scheme://logmeout:now@$http_host/graph/;
+                    }
+
+                    proxy_pass              http://127.0.0.1:3000/logout;
+                    proxy_read_timeout      600;
+                }
+
 		# Prometheus
 		location /prometheus {
 			proxy_pass		http://127.0.0.1:9090;


### PR DESCRIPTION
When HTTP authentication is enabled, the Grafana "sign out" does not work as expected, with navigation to any page other than the login page afterwards providing the user with immediate access once more. 

This could leave end-users believing that they have signed-out and perhaps provide unauthorised users with access.

Using the nginx location directive to specifically handle the logout page for Grafana, we can force the browser to reauthenticate if HTTP authentication is enabled.