### PR TITLE
PMM-2000: issues for pmm-managed starting and stopping

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -170,14 +170,16 @@ autorestart = true
 
 [program:pmm-managed]
 priority = 13
-command =
-    /usr/sbin/pmm-managed
-        -prometheus-config /etc/prometheus.yml
-        -prometheus-url http://127.0.0.1:9090/prometheus
-        -db-name pmm-managed
-        -db-username pmm-managed
-        -db-password pmm-managed
+command = bash -c '/usr/bin/mysqladmin ping 2>&1 &&
+                   /usr/sbin/pmm-managed
+                      -prometheus-config /etc/prometheus.yml
+                      -prometheus-url http://127.0.0.1:9090/prometheus
+                      -db-name pmm-managed
+                      -db-username pmm-managed
+                      -db-password pmm-managed
+                   || sleep 7'
 stdout_logfile = /var/log/pmm-managed.log
 stderr_logfile = /var/log/pmm-managed.log
 startretries = 1000000
 autorestart = true
+stopasgroup = true


### PR DESCRIPTION
  - `supervisorctl stop pmm-managed` does not stop the service
  - pmm-managed seems to beat MySQL to start and errors as it can't connect

Using `mysqladmin ping` and adding a delay on failure seems to avoid the connection errors, whilst forcing all processes to terminate as a group seems to stop `pmm-managed` as expected.

Having `pmm-managed` wait for MySQL connectivity for a configurable timeout would seem to solve both of theses issues, but that would need to be addressed outside of this PR