### PR TITLE
PMM-2184: Permanent redirects break when using port forwarding

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -27,10 +27,10 @@
 			set		$setup_type "${setup_type}-protected";
 		}
 		if ($setup_type = "ovf-ami") {
-			rewrite		^/$ /password-page/ permanent;
+			rewrite		^/$ $scheme://$http_host/password-page/ permanent;
 		}
 		if ($setup_type ~ "-protected") {
-			rewrite		^/password-page / permanent;
+			rewrite		^/password-page $scheme://$http_host/ permanent;
 		}
 
 		root			/usr/share/pmm-server/landing-page;
@@ -38,7 +38,7 @@
 		auth_basic_user_file	/srv/nginx/.htpasswd;
 
 		# Grafana
-		rewrite				^/$ /graph/ permanent;
+		rewrite				^/$ $scheme://$http_host/graph/ permanent;
 		rewrite				^/graph$ /graph/;
 		location /graph {
 			proxy_pass		http://127.0.0.1:3000;


### PR DESCRIPTION
The port is being lost during redirection, because NGINX runs on port 80/443 and sends the location back, which may be incorrect.

```
⇒ curl --silent --output /dev/null --insecure --dump-header /dev/stdout https://192.168.56.10:8443/
HTTP/1.1 301 Moved Permanently
Server: nginx
Date: Fri, 02 Mar 2018 14:43:40 GMT
Content-Type: text/html
Content-Length: 178
Location: https://192.168.56.10/graph/
Connection: keep-alive
Strict-Transport-Security: max-age=63072000; includeSubDomains
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
Cache-Control: no-store
Pragma: no-cache
```