### PR TITLE
PMM-2448 basic support for rule_files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,3 +33,5 @@ services:
       - ORCHESTRATOR_PASSWORD=orc_client_password
       - SERVER_USER=pmm
       - SERVER_PASSWORD=
+      - PROMETHEUS_EVALUATION_INTERVAL=60s
+      - PROMETHEUS_RULE_FILES=

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,6 +31,9 @@ else
 fi
 sed -i "s/ENV_METRICS_MEMORY_MULTIPLIED/${METRICS_MEMORY_MULTIPLIED}/" /etc/supervisord.d/pmm.ini
 
+sed -i "s/ENV_PROMETHEUS_EVALUATION_INTERVAL/${PROMETHEUS_EVALUATION_INTERVAL:-60s}/" /etc/prometheus.yml
+sed -i "s/ENV_PROMETHEUS_RULE_FILES/[${PROMETHEUS_RULE_FILES:-}]/" /etc/prometheus.yml
+
 # Orchestrator
 if [[ "${ORCHESTRATOR_ENABLED}" = "true" ]]; then
     sed -i "s/orc_client_user/${ORCHESTRATOR_USER:-orc_client_user}/" /etc/orchestrator.conf.json

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,7 +1,9 @@
 global:
   scrape_interval:     60s
   scrape_timeout:      10s
-  evaluation_interval: 60s
+  evaluation_interval: ENV_PROMETHEUS_EVALUATION_INTERVAL
+
+rule_files: ENV_PROMETHEUS_RULE_FILES
 
 scrape_configs:
   - job_name: prometheus


### PR DESCRIPTION
In order to be able to add prometheus rules I added two new env variables

```
+      - PROMETHEUS_EVALUATION_INTERVAL=60s
+      - PROMETHEUS_RULE_FILES=
```

where PROMETHEUS_RULE_FILES must be a single or comma delimited glob list i.e.
```
PROMETHEUS_RULE_FILES=/etc/prometheus.rules.d/*.yml
```

This allow to mount a new dir as volume containing the rule files

--volume /local/path/to/rules:/etc/prometheus.rules.d