### PR TITLE
PMM-2399: Entrypoint failure when DISABLE_UPDATES is enabled

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,7 +53,7 @@ if [ -n "${SERVER_PASSWORD}" -a -z "${UPDATE_MODE}" ]; then
 fi
 
 # Hide update button
-if [[ $DISABLE_UPDATES =~ ^(1|t|T|TRUE|true|True)$ ]]; then
+if [[ $DISABLE_UPDATES =~ ^(1|t|T|TRUE|true|True)$ ]] && [[ -f /usr/share/pmm-server/landing-page/index.html ]]; then
     sed -i "s/fa-refresh/fa-refresh hidden/" /usr/share/pmm-server/landing-page/index.html
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,12 +53,8 @@ if [ -n "${SERVER_PASSWORD}" -a -z "${UPDATE_MODE}" ]; then
 fi
 
 # Hide update button
-if [[ $DISABLE_UPDATES =~ ^(1|t|T|TRUE|true|True)$ ]]; then
-    if [[ -f /usr/share/pmm-server/landing-page/index.html ]]; then
-        sed -i "s/fa-refresh/fa-refresh hidden/" /usr/share/pmm-server/landing-page/index.html
-    elif [[ -f /var/lib/grafana/plugins/pmm-app/dist/pmm-update-panel/index.html ]]; then
-        sed -i "s/fa-download/fa-download hidden/" /var/lib/grafana/plugins/pmm-app/dist/pmm-update-panel/index.html
-    fi
+if [[ $DISABLE_UPDATES =~ ^(1|t|T|TRUE|true|True)$ ]] && [[ -f /usr/share/pmm-server/landing-page/index.html ]]; then
+    sed -i "s/fa-refresh/fa-refresh hidden/" /usr/share/pmm-server/landing-page/index.html
 fi
 
 # Upgrade

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,8 +53,12 @@ if [ -n "${SERVER_PASSWORD}" -a -z "${UPDATE_MODE}" ]; then
 fi
 
 # Hide update button
-if [[ $DISABLE_UPDATES =~ ^(1|t|T|TRUE|true|True)$ ]] && [[ -f /usr/share/pmm-server/landing-page/index.html ]]; then
-    sed -i "s/fa-refresh/fa-refresh hidden/" /usr/share/pmm-server/landing-page/index.html
+if [[ $DISABLE_UPDATES =~ ^(1|t|T|TRUE|true|True)$ ]]; then
+    if [[ -f /usr/share/pmm-server/landing-page/index.html ]]; then
+        sed -i "s/fa-refresh/fa-refresh hidden/" /usr/share/pmm-server/landing-page/index.html
+    elif [[ -f /var/lib/grafana/plugins/pmm-app/dist/pmm-update-panel/index.html ]]; then
+        sed -i "s/fa-download/fa-download hidden/" /var/lib/grafana/plugins/pmm-app/dist/pmm-update-panel/index.html
+    fi
 fi
 
 # Upgrade


### PR DESCRIPTION
The landing page has been removed, but the detection of DISABLE_UPDATES in the entrypoint errors trying to hide the button.