### PR TITLE
Fix Grafana SSL activation

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -55,7 +55,7 @@
 		rewrite				^/$ $scheme://$http_host/graph/ permanent;
 		rewrite				^/graph$ /graph/;
 		location /graph {
-			proxy_pass		http://127.0.0.1:3000;
+			proxy_pass		$scheme://127.0.0.1:3000;
 			rewrite			^/graph/(.*) /$1 break;
 			proxy_read_timeout	600;
 		}
@@ -66,7 +66,7 @@
                 return 307 $scheme://logmeout:now@$http_host/graph/;
             }
 
-            proxy_pass              http://127.0.0.1:3000/logout;
+            proxy_pass              $scheme://127.0.0.1:3000/logout;
             proxy_read_timeout      600;
         }
 


### PR DESCRIPTION
I added the certificate with a docker volume at the good place and the Grafana server only returns "Client sent an HTTP request to an HTTPS server." errors if I add `protocol = https` in the grafana.ini.

Everything works if I add an `s` to the http of the `proxy_pass http://127.0.0.1:3000`, but it's not suitable.
Everything also works if I replace the http with the `$scheme` variable to keep the protocol used by the client.

```
    # Grafana
    rewrite ^/$ $scheme://$http_host/graph/;
    rewrite ^/graph$ /graph/;
    location /graph {
      proxy_cookie_path / "/;";
      proxy_pass http://127.0.0.1:3000; # <== Works with an `s` here, or with `$scheme` instead of `http`
      rewrite ^/graph/(.*) /$1 break;
      proxy_read_timeout 600;
    }
```

This configuration is outside the configuration volume `/srv`.


I tried adding X-Forwarded- * headers but it's ignored by Grafana:
```
proxy_set_header X-Real-IP $remote_addr;
proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
proxy_set_header X-Forwarded-Proto $scheme;
proxy_set_header X-Forwarded-Server $host;
proxy_set_header X-Forwarded-Host $host;
proxy_set_header Host  $host;
```