### PR TITLE
PMM-6992 Send X-Forwarded-For header with proxied requests

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -41,6 +41,11 @@
     ssl_trusted_certificate /srv/nginx/ca-certs.pem;
     ssl_dhparam /srv/nginx/dhparam.pem;
 
+
+    # Enable passing of the remote user's IP address to all
+    # proxied services using the X-Forwarded-For header
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
     # Enable auth_request for all locations, including root
     # (but excluding /auth_request and /setup below).
     auth_request /auth_request;
@@ -97,7 +102,6 @@
     location /graph {
       proxy_cookie_path / "/;";
       proxy_pass http://127.0.0.1:3000;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       rewrite ^/graph/(.*) /$1 break;
       proxy_read_timeout 600;
     }

--- a/nginx.conf
+++ b/nginx.conf
@@ -97,6 +97,7 @@
     location /graph {
       proxy_cookie_path / "/;";
       proxy_pass http://127.0.0.1:3000;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       rewrite ^/graph/(.*) /$1 break;
       proxy_read_timeout 600;
     }


### PR DESCRIPTION
- [ ] https://github.com/Percona-Lab/pmm-submodules/pull/1268

The NGINX config does not pass on the IP of the user, so when viewing
active sessions you will only see 127.0.0.1, or similar.

Adding `X-Forwarded-For` header to be passed on with proxied
requests for `/graph` to solve this issue.

Leaving other locations for PMM team to review