### PR TITLE
Fix Swagger UI

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -149,9 +149,8 @@
 
     # Swagger UI
     rewrite ^/swagger$ $1/swagger/;
-    rewrite ^/swagger.json$ /swagger/swagger.json;
     location /swagger {
-      alias /usr/share/pmm-server/swagger/;
+      root /usr/share/pmm-server/swagger/;
       try_files $uri /swagger-ui.html break;
     }
 


### PR DESCRIPTION
Nginx was missconfigured. No files exept /swagger-ui.html were being send because it was a fallback.
Now, Nginx sends files that are needed to run Swagger UI.