### PR TITLE
PMM-7464 NGINX misconfiguration leads to log storm

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -123,6 +123,7 @@
     location /victoriametrics/ {
       proxy_pass http://127.0.0.1:9090/prometheus/;
       proxy_read_timeout 600;
+      client_body_buffer_size 10m;
     }
 
     # VMAlert


### PR DESCRIPTION
When using push-mode with `vmagent`, if an instance is unable to
successfully push for a somewhat trivial amount of time then the
resulting backlog is causing a log storm for NGINX errors:

```
a client request body is buffered to a temporary file /var/cache/nginx/client_temp/00000????? while sending to client, client: 10.x.x.x, server: _, request: "POST /victoriametrics/api/v1/write HTTP/1.1", host: "10.x.x.x:8443"
```

Within a short amount of time, 75k entries had appeared.
Increasing the `client_body_buffer_size` to accept a complete body
seemed to resolve this.