### PR TITLE
PMM-7627 Rotate NGINX logs at container start

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,5 +5,13 @@ set -o errexit
 # pmm-managed-init validates environment variables.
 pmm-managed-init
 
+# Perform NGINX logrotation
+if [ "${PMM_NGINX_LOGROTATE:=1}" = "1" ]; then
+    find /srv/logs -type f -name nginx\*log -size +"${PMM_NGINX_LOGROTATE_SIZE:=50M}" -not -name nginx.startup.log | while read -r logfile; do
+        mv -v "${logfile}" "${logfile/.log/.$(date -Id).log}"
+    done
+    find /srv/logs -type f -name nginx\*.log -mtime +"${PMM_NGINX_LOGROTATE_DAYS:=7}" -not -name nginx.startup.log -print -delete
+fi
+
 # Start supervisor in foreground
 exec supervisord -n -c /etc/supervisord.conf


### PR DESCRIPTION
Currently, only the log created by `supervisord` for NGINX is
managed, which can lead to NGINX logs getting out of control in size.

* Added `PMM_NGINX_LOGROTATE`, default is enabled, to the entrypoint
  to allow control of log rotation
* Added `PMM_NGINX_LOGROTATE_SIZE`, default is 50M, to control
  the desired size for rotation
* Added `PMM_NGINX_LOGROTATE_DAYS`, default is 7, to control the
  number of days before files are deleted
* Finds the NGINX logs that are larger than the specified size and
  rotates them, before deleting any logs outside of the retention
  period.