### PR TITLE
Remove setting GOPATH for pmm-update

### DIFF
--- a/rhel/SPECS/pmm-update.spec
+++ b/rhel/SPECS/pmm-update.spec
@@ -48,8 +48,6 @@ mkdir -p src/github.com/percona
 ln -s $(pwd) src/%{provider}
 
 %build
-export GOPATH=$(pwd)/
-
 export PMM_RELEASE_VERSION=%{full_pmm_version}
 export PMM_RELEASE_FULLCOMMIT=%{commit}
 export PMM_RELEASE_BRANCH=""


### PR DESCRIPTION
FB: https://github.com/Percona-Lab/pmm-submodules/pull/1663

It should fix build:
```
 make release

env CGO_ENABLED=0 go build -v -ldflags " -X 'github.com/percona/pmm/version.ProjectName=pmm-update' -X 'github.com/percona/pmm/version.Version=2.16.0' -X 'github.com/percona/pmm/version.PMMVersion=2.16.0' -X 'github.com/percona/pmm/version.Timestamp=1617706662' -X 'github.com/percona/pmm/version.FullCommit=42a48191207a7c93246acbb8f001780d0bbb0f53' -X 'github.com/percona/pmm/version.Branch=' " -o bin/pmm-update

$GOPATH/go.mod exists but should not

make: *** [release] Error 1
```