### PR TITLE
PMM-8169 Improve Release date capture for PMM server

### DIFF
--- a/rhel/SPECS/pmm-update.spec
+++ b/rhel/SPECS/pmm-update.spec
@@ -13,7 +13,7 @@
 %global commit	        592eddf656bce32a11bd958af0a32c62bd5ea34c
 %global shortcommit	    %(c=%{commit}; echo ${c:0:7})
 %define build_timestamp %(date -u +"%y%m%d%H%M")
-%define release         57
+%define release         58
 %define rpm_release     %{release}.%{build_timestamp}.%{shortcommit}%{?dist}
 
 %global install_golang 0
@@ -76,6 +76,9 @@ install -p -m 0755 bin/pmm-update %{buildroot}%{_sbindir}/
 # Specifically, the change date is ignored – RPM's "Buildtime" is used instead.
 
 %changelog
+* Thu Jun 24 2021 Denys Kondratenko <denys.kondratenko@percona.com> - 2.19.0-58
+- https://per.co.na/pmm/2.19.0
+
 * Tue Jun 01 2021 Nurlan Moldomurov <nurlan.moldomurov@percona.com> - 2.18.0-57
 - https://per.co.na/pmm/2.18.0
 


### PR DESCRIPTION
Setup pmm-update package version earlier so it wouldn't need to be
rebuild on the date of release. Will fully work starting from the next
release after this lands.