### PR TITLE
Update version to 2.20.0

### DIFF
--- a/rhel/SPECS/pmm-update.spec
+++ b/rhel/SPECS/pmm-update.spec
@@ -13,7 +13,7 @@
 %global commit	        592eddf656bce32a11bd958af0a32c62bd5ea34c
 %global shortcommit	    %(c=%{commit}; echo ${c:0:7})
 %define build_timestamp %(date -u +"%y%m%d%H%M")
-%define release         58
+%define release         59
 %define rpm_release     %{release}.%{build_timestamp}.%{shortcommit}%{?dist}
 
 %global install_golang 0
@@ -76,6 +76,9 @@ install -p -m 0755 bin/pmm-update %{buildroot}%{_sbindir}/
 # Specifically, the change date is ignored – RPM's "Buildtime" is used instead.
 
 %changelog
+* Fri Jun 25 2021 Denys Kondratenko <denys.kondratenko@percona.com> - 2.20.0-59
+- https://per.co.na/pmm/2.20.0
+
 * Thu Jun 24 2021 Denys Kondratenko <denys.kondratenko@percona.com> - 2.19.0-58
 - https://per.co.na/pmm/2.19.0
 


### PR DESCRIPTION
after #274 we need to update to actual version. 

commit from #274 would be cherry-picked to the `release-2.19.0` branch in a day of the release.