### PR TITLE
PMM-9358 Upgrade victoriametrics from 1.60.0 to 1.69.0 version

### DIFF
--- a/rhel/SPECS/victoriametrics.spec
+++ b/rhel/SPECS/victoriametrics.spec
@@ -9,10 +9,10 @@
 
 %global repo            VictoriaMetrics
 %global provider        github.com/VictoriaMetrics/%{repo}
-%global commit          pmm-6401-v1.60.0
+%global commit          pmm-6401-v1.69.0
 
 Name:           percona-victoriametrics
-Version:        1.60.0
+Version:        1.69.0
 Release:        1%{?dist}
 Summary:        VictoriaMetrics monitoring solution and time series database
 License:        Apache-2.0
@@ -50,7 +50,10 @@ install -D -p -m 0755 ./bin/vmalert-pure %{buildroot}%{_sbindir}/vmalert
 
 
 %changelog
-* Thu Jun  3 2021 Vadim Yalovets <vadim.yalovets@percona.com> - 1.60.0-1
+* Thu Dec 22 2021 Anton Bystrov <anton.bystrov@simbirsoft.com> - 1.69.0-1
+- upgrade victoriametrics to 1.69.0 release
+
+* Thu Jun 3 2021 Vadim Yalovets <vadim.yalovets@percona.com> - 1.60.0-1
 - upgrade victoriametrics to 1.60.0 release
 
 * Wed Feb 10 2021 Vadim Yalovets <vadim.yalovets@percona.com> - 1.53.1-1
@@ -58,7 +61,6 @@ install -D -p -m 0755 ./bin/vmalert-pure %{buildroot}%{_sbindir}/vmalert
 
 * Wed Jan 13 2021 Vadim Yalovets <vadim.yalovets@percona.com> - 1.52.0-1
 - upgrade victoriametrics to 1.52.0 release
-
 
 * Thu Dec 24 2020 Vadim Yalovets <vadim.yalovets@percona.com> - 1.50.2-1
 - upgrade victoriametrics to 1.50.2 release


### PR DESCRIPTION
[PMM-9358](https://jira.percona.com/browse/PMM-9358) update victoria metrics to 1.69.0 version.